### PR TITLE
Update compact_str to v0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,6 +191,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "castaway"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46b662d08e94a6c8e715abef5e10e6fdf47c2be6375a5bb246b65c177d575eb7"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -252,10 +261,13 @@ dependencies = [
 
 [[package]]
 name = "compact_str"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c1785f81f79585b3b8ee322db384b2b4c0dfd22423c3f6fb9fd4b5a3de30cd2"
+checksum = "fb6f80f92629b81f5b17b616a99f72870556ca457bbbd99aeda7bb5d194316a2"
 dependencies = [
+ "castaway",
+ "itoa 1.0.1",
+ "ryu",
  "serde",
 ]
 
@@ -1604,6 +1616,12 @@ checksum = "1ee86d63972a7c661d1536fefe8c3c8407321c3df668891286de28abcd087360"
 dependencies = [
  "base64",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
 
 [[package]]
 name = "ryu"

--- a/dcompass/Cargo.toml
+++ b/dcompass/Cargo.toml
@@ -16,7 +16,7 @@ geoip-maxmind = []
 # console-subscriber = "^0.1"
 # tokio = { version = "^1", features = ["rt-multi-thread", "net", "fs", "macros", "io-util", "signal", "sync", "tracing"]}
 
-compact_str = { version = "^0.3", features = ["serde"]}
+compact_str = { version = "^0.4", features = ["serde"]}
 async-trait = "^0.1"
 domain = {version = "^0.6", features = ["bytes"]}
 futures = "^0.3"

--- a/dcompass/src/tests.rs
+++ b/dcompass/src/tests.rs
@@ -126,7 +126,7 @@ async fn check_fail_undef() {
             DrouteError::UpstreamError(UpstreamError::MissingTag(tag)) => tag,
             e => panic!("Not the right error type: {}", e),
         },
-        compact_str::CompactStr::new("undefined")
+        compact_str::CompactString::new("undefined")
     );
 }
 

--- a/droute/Cargo.toml
+++ b/droute/Cargo.toml
@@ -45,7 +45,7 @@ futures = "^0.3"
 tokio = { version = "^1", features = ["rt-multi-thread", "net", "fs", "macros", "io-util"]}
 
 # Logic-related dependencies
-compact_str = { version = "^0.3", features = ["serde"]}
+compact_str = { version = "^0.4", features = ["serde"]}
 pest = "^2"
 ron = "^0.7"
 pest_derive = "^2"

--- a/droute/src/lib.rs
+++ b/droute/src/lib.rs
@@ -38,7 +38,7 @@ compile_error!("You should only choose one TLS backend for DNS over HTTPS implem
 compile_error!("You should only choose one TLS backend for DNS over TLS implementation");
 
 use async_trait::async_trait;
-use compact_str::CompactStr;
+use compact_str::CompactString;
 
 /// All the builders
 // API guideline: when we are exporting, make sure we aggregate builders by pub using them in parent builder(s) modules.
@@ -73,7 +73,7 @@ const MAX_TTL: u32 = 86400_u32;
 const MAX_LEN: usize = 1024_usize;
 
 /// The type used for tag names in upstreams and routing tables.
-pub type Label = CompactStr;
+pub type Label = CompactString;
 
 /// Async TryInto
 #[async_trait]

--- a/droute/src/router/table/mod.rs
+++ b/droute/src/router/table/mod.rs
@@ -20,7 +20,7 @@ use super::upstreams::Upstreams;
 use crate::{AsyncTryInto, Label, Validatable, ValidateCell};
 use async_trait::async_trait;
 use bytes::{Bytes, BytesMut};
-use compact_str::CompactStr;
+use compact_str::CompactString;
 use domain::{
     base::{name::PushError, octets::ParseError, Message, ParsedDname, Rtype, ToDname},
     rdata::AllRecordData,
@@ -151,7 +151,7 @@ fn traverse(
     } else {
         bucket.get_mut(tag).unwrap().0.add(1);
         for dst in dsts {
-            if dst != CompactStr::new("end") {
+            if dst != CompactString::new("end") {
                 traverse(bucket, &dst)?;
             }
         }


### PR DESCRIPTION
**Context**
In the most recent version of [`compact_str`](https://github.com/ParkMyCar/compact_str), we renamed `CompactStr` to `CompactString`. You can continue to use `CompactStr` but there is a deprecation warning on it.

**Changes**
This PR updates `compact_str` to `v0.4`, renaming uses of `CompactStr` to `CompactString` to prevent the warning